### PR TITLE
fixing LANG env in order to detect memory settings correctly 

### DIFF
--- a/FireMotD
+++ b/FireMotD
@@ -31,6 +31,7 @@ ScriptVersion=" $(< "$ScriptPath" grep "# Version: " | head -n1 | awk '{print $3
 LC_ALL="C"
 LC_CTYPE="C"
 LC_NUMERIC="C"
+LANG="C"
 
 WriteLog () {
     if [ ! -z "$ScriptName" ] ; then


### PR DESCRIPTION
without LANG="C" the free command behaves different depending on the setting.
example german (de_DE):

```
free
              gesamt       benutzt     frei      gemns.  Puffer/Cache verfügbar
Speicher:    32790348    11589692     9664776     1054824    11535880    19898916
Auslagerungsspeicher:           0           0           0
```

```
LANG=C free
              total        used        free      shared  buff/cache   available
Mem:       32790348    11592644     9661816     1054820    11535888    19895972
Swap:             0           0           0

```