### PR TITLE
Regenerate the "all" template (FireMotD-template-all.json)

### DIFF
--- a/cron.d/FireMotD
+++ b/cron.d/FireMotD
@@ -1,1 +1,1 @@
-00 00 * * * root perl -e 'sleep int(rand(3600))' && /usr/local/bin/FireMotD -S &>/dev/null
+00 00 * * * root perl -e 'sleep int(rand(3600))' && /usr/local/bin/FireMotD -S -D all &>/dev/null


### PR DESCRIPTION
Needed to prevent these kind of errors while entering the host:

FireMotD: Info: No FireMotD ExportFile detected. Please generate with "sudo .\FireMotD -S"