### PR TITLE
Changed the spaces to tab on line 42 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ install:
 	mkdir -p $(DDIR)/data
 	mkdir -p $(DDIR)/templates
 	mkdir -p $(DDIR)/themes
-        mkdir -p $(DDIR)/cache
+	mkdir -p $(DDIR)/cache
 	cp templates/* $(DDIR)/templates
 	cp themes/* $(DDIR)/themes
 


### PR DESCRIPTION
In Makefile at line 42 there were 8 spaces which generated the following error when I tried to install firemotd:
Makefile:42: *** missing separator (did you mean TAB instead of 8 spaces?). Stop.

I've replaced the 8 spaces with the TAB.