### PR TITLE
Readme: Fix broken shell command due to non-existence directory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ sudo apt-get install bc sysstat jq moreutils
 
 Run this command from you homefolder:
 ```bash
-curl -s https://raw.githubusercontent.com/OutsideIT/FireMotD/master/FireMotD -o ~/tmp/FireMotD && chmod 755 ~/tmp/FireMotD && sudo ~/tmp/FireMotD -I -d && ~/tmp/FireMotD -G all -d
+curl -s https://raw.githubusercontent.com/OutsideIT/FireMotD/master/FireMotD -o /tmp/FireMotD && chmod 755 /tmp/FireMotD && sudo /tmp/FireMotD -I -d && /tmp/FireMotD -G all -d
 ```
 
 #### Generating caches


### PR DESCRIPTION
Currently command at 'Built-in Install function' is not working due to non-existence directory `~/tmp`

```bash
>> curl -s https://raw.githubusercontent.com/OutsideIT/FireMotD/master/FireMotD -o ~/tmp/FireMotD; echo $?
23 (CURLE_WRITE_ERROR)
```
Maybe the desired directory was `/tmp` instead of `~/tmp` ?